### PR TITLE
Made all components xref-clean.

### DIFF
--- a/riak_core.erl
+++ b/riak_core.erl
@@ -6,6 +6,10 @@
          ping/0
         ]).
 
+-ignore_xref([
+              ping/0
+             ]).
+
 %% Public API
 
 %% @doc Pings a random vnode to make sure communication is functional

--- a/riak_core_console.erl
+++ b/riak_core_console.erl
@@ -4,6 +4,10 @@
          leave/1,
          remove/1,
          ringready/1]).
+-ignore_xref([join/1,
+              leave/1,
+              remove/1,
+              ringready/1]).
 
 join([NodeStr]) ->
     try

--- a/riak_core_vnode.erl
+++ b/riak_core_vnode.erl
@@ -17,6 +17,10 @@
          handle_coverage/4,
          handle_exit/3]).
 
+-ignore_xref([
+             start_vnode/1
+             ]).
+
 -record(state, {partition}).
 
 %% API

--- a/riak_core_wm_ping.erl
+++ b/riak_core_wm_ping.erl
@@ -1,5 +1,6 @@
 -module({{appid}}_wm_ping).
 -export([init/1, to_html/2]).
+-ignore_xref([init/1, to_html/2, ping/2]).
 
 -include_lib("webmachine/include/webmachine.hrl").
 


### PR DESCRIPTION
No xref errors are shown any more, functions are put in ignore when they are used by a method xref can't figure.
