### PR TITLE
Pin riak_core in rebar.config to 2.1.0 tag

### DIFF
--- a/riak_core.rebar.config
+++ b/riak_core.rebar.config
@@ -1,5 +1,5 @@
 {sub_dirs, ["rel"]}.
 
 {deps, [
-    {riak_core, ".*", {git, "git://github.com/basho/riak_core", {branch, "2.0"}}}
+    {riak_core, ".*", {git, "git://github.com/basho/riak_core", {tag, "2.1.0"}}}
 ]}.


### PR DESCRIPTION
This is the minimum riak_core which will build on top of Erlang 17.  Also the 2.0 branch is officially deprecated.
